### PR TITLE
made camera move on keypress/mouse movement

### DIFF
--- a/client/src/sge/GraphicsGeometry.cpp
+++ b/client/src/sge/GraphicsGeometry.cpp
@@ -138,11 +138,22 @@ namespace sge {
     void ModelComposite::render(glm::vec3 modelPosition, float modelYaw) const {
         glUseProgram(sge::program);
         glBindVertexArray(VAO);
-        glm::mat4 model = glm::translate(glm::mat4(1.0f), modelPosition);
-        model = glm::rotate(model, glm::radians(modelYaw), glm::vec3(0.0f, 1.0f, 0.0f));
+        // glm::mat4 model = glm::translate(glm::mat4(1.0f), modelPosition);
+        // glm::mat4 model = glm::mat4(1.0f);
+        // model = glm::rotate(model, glm::radians(modelYaw), glm::vec3(0.0f, 1.0f, 0.0f));
         // todo? let the camera follow the model (change lookAt() params)
         // yaw (cursor movement) should rotate our player model AND the camera view, right? 
-        glm::mat4 modelview = glm::perspective(glm::radians(90.0f), (float)sge::windowWidth / (float)sge::windowHeight, 0.5f, 1000.0f) * glm::lookAt(glm::vec3(10, 10, 10), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0, 1, 0)) * model;
+        // TODO: put all this camera code into a modelview function? 
+        // TODO: this should be tied to the player, not the render call
+        glm::vec3 eyePos=modelPosition;
+        // TODO: refactor this into a separate function because ugly, add pitch
+        float yaw=modelYaw;
+        float pitch=0.0f;
+        glm::vec3 direction;
+        direction.x = cos(glm::radians(yaw)) * cos(glm::radians(pitch));
+        direction.y = sin(glm::radians(pitch));
+        direction.z = sin(glm::radians(yaw)) * cos(glm::radians(pitch));
+        glm::mat4 modelview = glm::perspective(glm::radians(90.0f), (float)sge::windowWidth / (float)sge::windowHeight, 0.5f, 1000.0f) * glm::lookAt(modelPosition, modelPosition+direction, glm::vec3(0, 1, 0));
         glUniformMatrix4fv(sge::modelViewPos, 1, GL_FALSE, &modelview[0][0]);
         for (unsigned int i = 0; i < meshes.size(); i++) {
             const Material &mat = materials[meshes[i].MaterialIndex];


### PR DESCRIPTION
made keypresses affect camera movement and mouse
this is using the modelPosition and modelYaw passed in to the render function; this should be cleaned up
ideally pass in eyePos/direction or eyePos/yaw/pitch and calculate the rest. the camera stuff should also be calculated in a helper because render's main goal is to actually render the object, not set up the camera