### PR TITLE
Animations experimentation

### DIFF
--- a/client/include/Client.h
+++ b/client/include/Client.h
@@ -23,3 +23,4 @@ extern std::unique_ptr<ClientGame> clientGame;
 // C++ inheritance only works when referencing objects as pointers/references
 extern std::vector<std::shared_ptr<sge::EntityState>> entities;
 extern std::vector<std::shared_ptr<sge::DynamicEntityState>> movementEntities;
+

--- a/client/include/Client.h
+++ b/client/include/Client.h
@@ -21,4 +21,5 @@ extern double lastX, lastY;
 extern bool enableInput;
 extern std::unique_ptr<ClientGame> clientGame;
 // C++ inheritance only works when referencing objects as pointers/references
-extern std::vector<std::unique_ptr<sge::EntityState>> entities;
+extern std::vector<std::shared_ptr<sge::EntityState>> entities;
+extern std::vector<std::shared_ptr<sge::DynamicEntityState>> movementEntities;

--- a/client/include/ClientGame.h
+++ b/client/include/ClientGame.h
@@ -25,6 +25,11 @@
 // to avoid circular dependency
 class ClientNetwork;
 
+enum PlayerAnimations {
+    NO_ANIMATION = -1,
+    WALKING = 0,
+};
+
 class ClientGame
 {
 
@@ -57,5 +62,8 @@ public:
     glm::vec3 positions[NUM_MOVEMENT_ENTITIES];
     float yaws[NUM_MOVEMENT_ENTITIES];
     float pitches[NUM_MOVEMENT_ENTITIES];
-    sge::ANIMATION animations[NUM_MOVEMENT_ENTITIES];
+    int animations[NUM_MOVEMENT_ENTITIES];
+
+    // Contains the indices between 0 and NUM_MOVEMENT_ENTITIES which correspond to players
+    std::vector<unsigned int> playerIndices;
 };

--- a/client/include/ClientGame.h
+++ b/client/include/ClientGame.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include "ClientNetwork.h"
 #include "NetworkData.h"
+#include "sge/GraphicsEntity.h"
 #include <glm/glm.hpp>
 
 // to avoid circular dependency
@@ -56,4 +57,5 @@ public:
     glm::vec3 positions[NUM_MOVEMENT_ENTITIES];
     float yaws[NUM_MOVEMENT_ENTITIES];
     float pitches[NUM_MOVEMENT_ENTITIES];
+    sge::ANIMATION animations[NUM_MOVEMENT_ENTITIES];
 };

--- a/client/include/sge/GraphicsConstants.h
+++ b/client/include/sge/GraphicsConstants.h
@@ -47,8 +47,8 @@ enum BufferIndex {
  */
 enum ModelIndex {
     MAP = 0,
-    PLAYER_0 = 1, // Rename to summer player or something lat
-    TEST_ANIMATION = 2,
+    BOX_PLAYER = 1, // Rename to summer player or something lat
+    BEAR = 2,
     NUM_MODELS
 };
 

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -6,6 +6,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <chrono>
+#include "GraphicsGeometry.h"
 
 namespace sge {
     /**
@@ -43,6 +44,7 @@ namespace sge {
         void update() override;
     protected:
         const size_t positionIndex;
+        ModelPose currPose;
         int currentAnimationIndex; // Which animation are we currently displaying? -1 for no animation
         float animationTime; // time within the animation loop (ranges from 0 to arbitrarily large numbers since the modelcomposite handles the looping)
         std::chrono::high_resolution_clock::time_point animationStartTime; // what was the computer's time when we last started the animation?

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -9,6 +9,11 @@
 #include "GraphicsGeometry.h"
 
 namespace sge {
+    enum ANIMATION {
+        NO_ANIMATION = -1,
+        WALKING = 0,
+    };
+
     /**
      * Class that wraps position and model information in a
      * memory-usage friendly package
@@ -42,9 +47,10 @@ namespace sge {
         DynamicEntityState(size_t modelIndex, size_t positionIndex);
         void draw() const override;
         void update() override;
+        void setAnimation(ANIMATION anim);
+    protected:
         void startAnimation(unsigned int animationIndex);
         void stopAnimation();
-    protected:
         const size_t positionIndex;
         ModelPose currPose;
         int currentAnimationIndex; // Which animation are we currently displaying? -1 for no animation

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
+#include <chrono>
 
 namespace sge {
     /**
@@ -42,7 +43,9 @@ namespace sge {
         void update() override;
     protected:
         const size_t positionIndex;
-        unsigned int animationTime;
+        int currentAnimationIndex; // Which animation are we currently displaying? -1 for no animation
+        float animationTime; // time within the animation loop (ranges from 0 to arbitrarily large numbers since the modelcomposite handles the looping)
+        std::chrono::high_resolution_clock::time_point animationStartTime; // what was the computer's time when we last started the animation?
     };
 
     class AnimatedEntityState : public EntityState {

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -42,11 +42,13 @@ namespace sge {
         DynamicEntityState(size_t modelIndex, size_t positionIndex);
         void draw() const override;
         void update() override;
+        void startAnimation(unsigned int animationIndex);
+        void stopAnimation();
     protected:
         const size_t positionIndex;
         ModelPose currPose;
         int currentAnimationIndex; // Which animation are we currently displaying? -1 for no animation
-        float animationTime; // time within the animation loop (ranges from 0 to arbitrarily large numbers since the modelcomposite handles the looping)
+        float animationTime; // time within the animation loop (ranges from 0 to the animation's duration
         std::chrono::high_resolution_clock::time_point animationStartTime; // what was the computer's time when we last started the animation?
     };
 

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -9,10 +9,6 @@
 #include "GraphicsGeometry.h"
 
 namespace sge {
-    enum ANIMATION {
-        NO_ANIMATION = -1,
-        WALKING = 0,
-    };
 
     /**
      * Class that wraps position and model information in a
@@ -47,7 +43,7 @@ namespace sge {
         DynamicEntityState(size_t modelIndex, size_t positionIndex);
         void draw() const override;
         void update() override;
-        void setAnimation(ANIMATION anim);
+        void setAnimation(unsigned int animationId);
     protected:
         void startAnimation(unsigned int animationIndex);
         void stopAnimation();

--- a/client/include/sge/GraphicsEntity.h
+++ b/client/include/sge/GraphicsEntity.h
@@ -18,6 +18,7 @@ namespace sge {
         EntityState(size_t modelIndex, glm::vec3 position, float yaw, float pitch, float roll);
         // Draw this element to the screen
         virtual void draw() const;
+        virtual void update();
     private:
         // Not constants because we might want an environment object with a set "trajectory" / looped animations
         float pitch;
@@ -38,8 +39,10 @@ namespace sge {
     public:
         DynamicEntityState(size_t modelIndex, size_t positionIndex);
         void draw() const override;
+        void update() override;
     protected:
         const size_t positionIndex;
+        unsigned int animationTime;
     };
 
     class AnimatedEntityState : public EntityState {

--- a/client/include/sge/GraphicsGeometry.h
+++ b/client/include/sge/GraphicsGeometry.h
@@ -112,7 +112,8 @@ namespace sge {
         virtual void render(const glm::vec3 &modelPosition, const float &modelYaw) const;
         virtual void renderPose(const glm::vec3 &modelPosition, const float &modelYaw, ModelPose pose) const;
 //        void render(glm::vec3 modelPosition, float modelYaw, float modelPitch, float modelRoll) const;
-        ModelPose animationPose(int animationId, float time);
+        ModelPose emptyModelPose();
+        void animationPose(int animationId, float time, ModelPose& outputModelPose);
     private:
         /**
          * Hierarchy of bones

--- a/client/include/sge/GraphicsGeometry.h
+++ b/client/include/sge/GraphicsGeometry.h
@@ -114,6 +114,9 @@ namespace sge {
 //        void render(glm::vec3 modelPosition, float modelYaw, float modelPitch, float modelRoll) const;
         ModelPose emptyModelPose();
         void animationPose(int animationId, float time, ModelPose& outputModelPose);
+        // given an animation's id and the number of milliseconds since its start, compute the corresponding tick within the animation loop
+        // handles looping the animation
+        float timeToAnimationTick(long long milliseconds, unsigned int animationId);
     private:
         /**
          * Hierarchy of bones

--- a/client/include/sge/GraphicsGeometry.h
+++ b/client/include/sge/GraphicsGeometry.h
@@ -116,7 +116,8 @@ namespace sge {
         void animationPose(int animationId, float time, ModelPose& outputModelPose);
         // given an animation's id and the number of milliseconds since its start, compute the corresponding tick within the animation loop
         // handles looping the animation
-        float timeToAnimationTick(long long milliseconds, unsigned int animationId);
+        float timeToAnimationTick(long long milliseconds, int animationId);
+        void setStillAnimation(unsigned int animationWhenStill, float animationTickWhenStill);
     private:
         /**
          * Hierarchy of bones
@@ -180,6 +181,8 @@ namespace sge {
         } bones;
         std::unordered_map<std::string, unsigned int> boneMap; // Auxiliary data structure when loading skeleton - maps Assimp bone names to integeres
         std::vector<Animation> animations;
+        unsigned int animationWhenStill;
+        float animationTickWhenStill;
         glm::mat4 animationGlobalInverse;
         unsigned int numBones;
         bool animated;

--- a/client/include/sge/GraphicsGeometry.h
+++ b/client/include/sge/GraphicsGeometry.h
@@ -109,9 +109,8 @@ namespace sge {
         ModelComposite(const std::string &filename);
         ~ModelComposite();
 
-//        virtual void renderPose();
         virtual void render(const glm::vec3 &modelPosition, const float &modelYaw) const;
-        virtual void renderPose(const glm::vec3 &modelPosition, const float &modelYaw, std::vector<glm::mat4> pose) const;
+        virtual void renderPose(const glm::vec3 &modelPosition, const float &modelYaw, ModelPose pose) const;
 //        void render(glm::vec3 modelPosition, float modelYaw, float modelPitch, float modelRoll) const;
         ModelPose animationPose(int animationId, float time);
     private:

--- a/client/src/Client.cpp
+++ b/client/src/Client.cpp
@@ -81,6 +81,7 @@ void clientLoop()
         // Render all entities that use the default shaders to the gBuffer
         for (unsigned int i = 0; i < entities.size(); i++) {
             entities[i]->draw();
+            entities[i]->update();
         }
 
         // Render framebuffer with postprocessing

--- a/client/src/Client.cpp
+++ b/client/src/Client.cpp
@@ -5,7 +5,8 @@
 #include "Client.h"
 
 std::unique_ptr<ClientGame> clientGame;
-std::vector<std::unique_ptr<sge::EntityState>> entities;
+std::vector<std::shared_ptr<sge::EntityState>> entities;
+std::vector<std::shared_ptr<sge::DynamicEntityState>> movementEntities;
 
 double lastX, lastY;    // last cursor position
 bool enableInput = false;
@@ -21,9 +22,11 @@ int main()
     sge::loadModels();
 
     // Create permanent graphics engine entities
-    entities.push_back(std::make_unique<sge::EntityState>(MAP, glm::vec3(0.0f,-3.0f,0.0f))); // with no collision (yet), this prevents player from falling under the map.
+    entities.push_back(std::make_shared<sge::EntityState>(MAP, glm::vec3(0.0f,-3.0f,0.0f))); // with no collision (yet), this prevents player from falling under the map.
     for (unsigned int i = 0; i < 4; i++) { // Player graphics entities
-        entities.push_back(std::make_unique<sge::DynamicEntityState>(TEST_ANIMATION, i));
+        std::shared_ptr<sge::DynamicEntityState> playerEntity = std::make_shared<sge::DynamicEntityState>(TEST_ANIMATION, i);
+        entities.push_back(playerEntity);
+        movementEntities.push_back(playerEntity);
     }
 
     clientGame = std::make_unique<ClientGame>();
@@ -78,10 +81,15 @@ void clientLoop()
 
         // Uncomment the below to display wireframes
 //        glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
+// 
+        for (unsigned int i = 0; i < movementEntities.size(); i++) {
+            movementEntities[i]->setAnimation(clientGame->animations[i]);
+        }
+ 
         // Render all entities that use the default shaders to the gBuffer
         for (unsigned int i = 0; i < entities.size(); i++) {
-            entities[i]->draw();
             entities[i]->update();
+            entities[i]->draw();
         }
 
         // Render framebuffer with postprocessing

--- a/client/src/Client.cpp
+++ b/client/src/Client.cpp
@@ -21,15 +21,16 @@ int main()
     // Load 3d models for graphics engine
     sge::loadModels();
 
+    clientGame = std::make_unique<ClientGame>();
+
     // Create permanent graphics engine entities
     entities.push_back(std::make_shared<sge::EntityState>(MAP, glm::vec3(0.0f,-3.0f,0.0f))); // with no collision (yet), this prevents player from falling under the map.
     for (unsigned int i = 0; i < 4; i++) { // Player graphics entities
-        std::shared_ptr<sge::DynamicEntityState> playerEntity = std::make_shared<sge::DynamicEntityState>(TEST_ANIMATION, i);
+        std::shared_ptr<sge::DynamicEntityState> playerEntity = std::make_shared<sge::DynamicEntityState>(BEAR, i);
         entities.push_back(playerEntity);
+        clientGame->playerIndices.push_back(movementEntities.size());
         movementEntities.push_back(playerEntity);
     }
-
-    clientGame = std::make_unique<ClientGame>();
 
     glfwSetFramebufferSizeCallback(sge::window, framebufferSizeCallback);
     // Register keyboard input callbacks
@@ -82,7 +83,7 @@ void clientLoop()
         // Uncomment the below to display wireframes
 //        glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 // 
-        for (unsigned int i = 0; i < movementEntities.size(); i++) {
+        for (unsigned int i = 0; i < NUM_MOVEMENT_ENTITIES; i++) {
             movementEntities[i]->setAnimation(clientGame->animations[i]);
         }
  

--- a/client/src/ClientGame.cpp
+++ b/client/src/ClientGame.cpp
@@ -1,5 +1,6 @@
 #include "ClientGame.h"
 
+
 ClientGame::ClientGame()
 {
     network = std::make_unique<ClientNetwork>(this);
@@ -7,8 +8,8 @@ ClientGame::ClientGame()
     std::cout << "Initializing client game world...\n";
     for (int i = 0; i < NUM_MOVEMENT_ENTITIES; i++) {
         positions[i] = glm::vec3(i*10.0f, 0.0f, -(i%2)*8.0f);
-        animations[i] = sge::NO_ANIMATION;
         yaws[i] = -90.0f;
+        animations[i] = -1; // always means no animation
     }
 
 	// send init packet
@@ -18,12 +19,13 @@ ClientGame::ClientGame()
 void ClientGame::handleServerActionEvent(ServerToClientPacket& updatePacket) {
     // Figure out animations
     // TODO: probably it should be the server's job, not the client's, to determine if something is moving
-    for (unsigned int i = 0; i < NUM_MOVEMENT_ENTITIES; i++) {
-        if (positions[i] != updatePacket.positions[i]) {
-            animations[i] = sge::WALKING;
+    for (unsigned int i = 0; i < NUM_PLAYER_ENTITIES; i++) {
+        unsigned int movementIndex = playerIndices[i];
+        if (positions[movementIndex] != updatePacket.positions[movementIndex]) {
+            animations[movementIndex] = WALKING;
         }
         else {
-            animations[i] = sge::NO_ANIMATION;
+            animations[movementIndex] = NO_ANIMATION;
         }
     }
     // Handle action update (change position, camera angle, HP, etc.)

--- a/client/src/ClientGame.cpp
+++ b/client/src/ClientGame.cpp
@@ -7,6 +7,7 @@ ClientGame::ClientGame()
     std::cout << "Initializing client game world...\n";
     for (int i = 0; i < NUM_MOVEMENT_ENTITIES; i++) {
         positions[i] = glm::vec3(i*10.0f, 0.0f, -(i%2)*8.0f);
+        animations[i] = sge::NO_ANIMATION;
         yaws[i] = -90.0f;
     }
 
@@ -15,7 +16,16 @@ ClientGame::ClientGame()
 }
 
 void ClientGame::handleServerActionEvent(ServerToClientPacket& updatePacket) {
-
+    // Figure out animations
+    // TODO: probably it should be the server's job, not the client's, to determine if something is moving
+    for (unsigned int i = 0; i < NUM_MOVEMENT_ENTITIES; i++) {
+        if (positions[i] != updatePacket.positions[i]) {
+            animations[i] = sge::WALKING;
+        }
+        else {
+            animations[i] = sge::NO_ANIMATION;
+        }
+    }
     // Handle action update (change position, camera angle, HP, etc.)
     memcpy(&positions, &updatePacket.positions, sizeof(positions));
     memcpy(&yaws, &updatePacket.yaws, sizeof(yaws));

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -48,7 +48,16 @@ void sge::DynamicEntityState::draw() const {
 
 void sge::DynamicEntityState::update() {
     // std::cout << "updating animation time\n";
-    models[modelIndex]->animationPose(0, animationTime, currPose);
+    if (currentAnimationIndex == -1) {
+        animationTime = 0;
+    }
+    else {
+        auto now = std::chrono::high_resolution_clock::now();
+        auto timeSinceStart = now - animationStartTime;
+        long long milliSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceStart).count();
+        animationTime = models[modelIndex]->timeToAnimationTick(milliSinceStart,currentAnimationIndex);
+    }
+    models[modelIndex]->animationPose(currentAnimationIndex, animationTime, currPose);
     animationTime++;
 }
 

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -47,17 +47,11 @@ void sge::DynamicEntityState::draw() const {
 }
 
 void sge::DynamicEntityState::update() {
-    if (currentAnimationIndex == -1) {
-        // use frame 0 of animation 0 for when we're not moving
-        models[modelIndex]->animationPose(0, 0, currPose);
-    }
-    else {
-        auto now = std::chrono::high_resolution_clock::now();
-        auto timeSinceStart = now - animationStartTime;
-        long long milliSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceStart).count();
-        animationTime = models[modelIndex]->timeToAnimationTick(milliSinceStart,currentAnimationIndex);
-        models[modelIndex]->animationPose(currentAnimationIndex, animationTime, currPose);
-    }
+    auto now = std::chrono::high_resolution_clock::now();
+    auto timeSinceStart = now - animationStartTime;
+    long long milliSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceStart).count();
+    animationTime = models[modelIndex]->timeToAnimationTick(milliSinceStart,currentAnimationIndex);
+    models[modelIndex]->animationPose(currentAnimationIndex, animationTime, currPose);
 }
 
 void sge::DynamicEntityState::startAnimation(unsigned int animationId) {
@@ -65,18 +59,10 @@ void sge::DynamicEntityState::startAnimation(unsigned int animationId) {
     animationStartTime = std::chrono::high_resolution_clock::now();
 }
 
-void sge::DynamicEntityState::stopAnimation() {
-    currentAnimationIndex = -1;
-}
-
 void sge::DynamicEntityState::setAnimation(unsigned int animationId) {
     if (animationId == currentAnimationIndex) {
         return;
-    }
-    else if (animationId == -1) {
-        stopAnimation();
-    }
-    else {
+    } else {
         startAnimation(animationId);
     }
 }

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -30,16 +30,23 @@ void sge::EntityState::draw() const {
     models[modelIndex]->render(position, yaw);
 }
 
+void sge::EntityState::update() {}
+
 sge::DynamicEntityState::DynamicEntityState(size_t modelIndex, size_t positionIndex) : EntityState(modelIndex), positionIndex(positionIndex) {
+    animationTime = 0;
 }
 
 /**
  * Draw entity to screen
  */
 void sge::DynamicEntityState::draw() const {
-    ModelPose pose = models[modelIndex]->animationPose(0, 700);
+    ModelPose pose = models[modelIndex]->animationPose(0, animationTime);
     models[modelIndex]->renderPose(clientGame->positions[positionIndex], clientGame->yaws[positionIndex], pose);
 }
 
+void sge::DynamicEntityState::update() {
+    // std::cout << "updating animation time\n";
+    animationTime = (animationTime + 1) % 1700;
+}
 
 

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -47,18 +47,37 @@ void sge::DynamicEntityState::draw() const {
 }
 
 void sge::DynamicEntityState::update() {
-    // std::cout << "updating animation time\n";
     if (currentAnimationIndex == -1) {
-        animationTime = 0;
+        // use frame 0 of animation 0 for when we're not moving
+        // TODO: change this to something better
+        models[modelIndex]->animationPose(0, 0, currPose);
     }
     else {
         auto now = std::chrono::high_resolution_clock::now();
         auto timeSinceStart = now - animationStartTime;
         long long milliSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceStart).count();
         animationTime = models[modelIndex]->timeToAnimationTick(milliSinceStart,currentAnimationIndex);
+        models[modelIndex]->animationPose(currentAnimationIndex, animationTime, currPose);
     }
-    models[modelIndex]->animationPose(currentAnimationIndex, animationTime, currPose);
-    animationTime++;
 }
 
+void sge::DynamicEntityState::startAnimation(unsigned int animationId) {
+    currentAnimationIndex = animationId;
+    animationStartTime = std::chrono::high_resolution_clock::now();
+}
 
+void sge::DynamicEntityState::stopAnimation() {
+    currentAnimationIndex = -1;
+}
+
+void sge::DynamicEntityState::setAnimation(ANIMATION anim) {
+    if (anim == currentAnimationIndex) {
+        return;
+    }
+    else if (anim == NO_ANIMATION) {
+        stopAnimation();
+    }
+    else {
+        startAnimation(anim);
+    }
+}

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -49,7 +49,6 @@ void sge::DynamicEntityState::draw() const {
 void sge::DynamicEntityState::update() {
     if (currentAnimationIndex == -1) {
         // use frame 0 of animation 0 for when we're not moving
-        // TODO: change this to something better
         models[modelIndex]->animationPose(0, 0, currPose);
     }
     else {
@@ -70,14 +69,14 @@ void sge::DynamicEntityState::stopAnimation() {
     currentAnimationIndex = -1;
 }
 
-void sge::DynamicEntityState::setAnimation(ANIMATION anim) {
-    if (anim == currentAnimationIndex) {
+void sge::DynamicEntityState::setAnimation(unsigned int animationId) {
+    if (animationId == currentAnimationIndex) {
         return;
     }
-    else if (anim == NO_ANIMATION) {
+    else if (animationId == -1) {
         stopAnimation();
     }
     else {
-        startAnimation(anim);
+        startAnimation(animationId);
     }
 }

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -36,18 +36,19 @@ sge::DynamicEntityState::DynamicEntityState(size_t modelIndex, size_t positionIn
     currentAnimationIndex = 0; // Which animation are we currently displaying? -1 for no animation
     animationTime = 0; // time within the animation loop (ranges from 0 to the animation's duration)
     animationStartTime = std::chrono::high_resolution_clock::now();
+    currPose = models[modelIndex]->emptyModelPose();
 }
 
 /**
  * Draw entity to screen
  */
 void sge::DynamicEntityState::draw() const {
-    ModelPose pose = models[modelIndex]->animationPose(0, animationTime);
-    models[modelIndex]->renderPose(clientGame->positions[positionIndex], clientGame->yaws[positionIndex], pose);
+    models[modelIndex]->renderPose(clientGame->positions[positionIndex], clientGame->yaws[positionIndex], currPose);
 }
 
 void sge::DynamicEntityState::update() {
     // std::cout << "updating animation time\n";
+    models[modelIndex]->animationPose(0, animationTime, currPose);
     animationTime++;
 }
 

--- a/client/src/sge/GraphicsEntity.cpp
+++ b/client/src/sge/GraphicsEntity.cpp
@@ -33,7 +33,9 @@ void sge::EntityState::draw() const {
 void sge::EntityState::update() {}
 
 sge::DynamicEntityState::DynamicEntityState(size_t modelIndex, size_t positionIndex) : EntityState(modelIndex), positionIndex(positionIndex) {
-    animationTime = 0;
+    currentAnimationIndex = 0; // Which animation are we currently displaying? -1 for no animation
+    animationTime = 0; // time within the animation loop (ranges from 0 to the animation's duration)
+    animationStartTime = std::chrono::high_resolution_clock::now();
 }
 
 /**
@@ -46,7 +48,7 @@ void sge::DynamicEntityState::draw() const {
 
 void sge::DynamicEntityState::update() {
     // std::cout << "updating animation time\n";
-    animationTime = (animationTime + 1) % 1700;
+    animationTime++;
 }
 
 

--- a/client/src/sge/GraphicsGeometry.cpp
+++ b/client/src/sge/GraphicsGeometry.cpp
@@ -492,9 +492,8 @@ namespace sge {
      * @param time Timestamp to retrieve pose
      * @return Model's pose at given timestamp
      */
-    ModelPose ModelComposite::animationPose(int animationId, float time) {
+    void ModelComposite::animationPose(int animationId, float time, ModelPose& outputModelPose) {
         assert(animationId >= 0  && animationId < animations.size() && animated);
-        ModelPose out(MAX_BONES, glm::mat4(1));
         Animation anim = animations[animationId];
         glm::mat4 accumulator(1);
         // apply animation loop
@@ -502,8 +501,12 @@ namespace sge {
             time -= ((int)(time / anim.duration)) * anim.duration;
         }
         // Recursively construct final transformation matrices for each bone
-        recursePose(out, anim, time, accumulator, bones.root);
-        return out;
+        recursePose(outputModelPose, anim, time, accumulator, bones.root);
+    }
+
+    ModelPose ModelComposite::emptyModelPose() {
+        ModelPose pose(MAX_BONES, glm::mat4(1));
+        return pose;
     }
 
     void ModelComposite::renderPose(const glm::vec3 &modelPosition, const float &modelYaw, std::vector<glm::mat4> pose) const {

--- a/client/src/sge/GraphicsGeometry.cpp
+++ b/client/src/sge/GraphicsGeometry.cpp
@@ -497,6 +497,10 @@ namespace sge {
         ModelPose out(MAX_BONES, glm::mat4(1));
         Animation anim = animations[animationId];
         glm::mat4 accumulator(1);
+        // apply animation loop
+        if (time > anim.duration) {
+            time -= ((int)(time / anim.duration)) * anim.duration;
+        }
         // Recursively construct final transformation matrices for each bone
         recursePose(out, anim, time, accumulator, bones.root);
         return out;

--- a/client/src/sge/GraphicsGeometry.cpp
+++ b/client/src/sge/GraphicsGeometry.cpp
@@ -487,7 +487,6 @@ namespace sge {
 
     /**
      * Return model pose for a given animation at a given timestamp
-     * TODO: change this to use an output parameter cus creating a new array every time is slow as fuck
      * @param animationId Model's animation identifier
      * @param time Timestamp to retrieve pose
      * @return Model's pose at given timestamp

--- a/client/src/sge/GraphicsGeometry.cpp
+++ b/client/src/sge/GraphicsGeometry.cpp
@@ -496,10 +496,6 @@ namespace sge {
         assert(animationId >= 0  && animationId < animations.size() && animated);
         Animation anim = animations[animationId];
         glm::mat4 accumulator(1);
-        // apply animation loop
-        if (time > anim.duration) {
-            time -= ((int)(time / anim.duration)) * anim.duration;
-        }
         // Recursively construct final transformation matrices for each bone
         recursePose(outputModelPose, anim, time, accumulator, bones.root);
     }
@@ -507,6 +503,17 @@ namespace sge {
     ModelPose ModelComposite::emptyModelPose() {
         ModelPose pose(MAX_BONES, glm::mat4(1));
         return pose;
+    }
+
+    float ModelComposite::timeToAnimationTick(long long milliseconds, unsigned int animationId) {
+        assert(animationId < animations.size() && animated);
+        Animation anim = animations[animationId];
+        float ticks = milliseconds * anim.ticksPerSecond / 1000;
+        // apply animation loop
+        if (ticks > anim.duration) {
+            ticks -= ((int)(ticks / anim.duration)) * anim.duration;
+        }
+        return ticks;
     }
 
     void ModelComposite::renderPose(const glm::vec3 &modelPosition, const float &modelYaw, std::vector<glm::mat4> pose) const {

--- a/client/src/sge/ShittyGraphicsEngine.cpp
+++ b/client/src/sge/ShittyGraphicsEngine.cpp
@@ -81,4 +81,6 @@ void sge::loadModels() {
     for (unsigned int i = 0; i < NUM_MODELS; i++) {
         models.push_back(std::make_unique<ModelComposite>(pathPrefix + filePaths[i]));
     }
+    // manually set the bear to use animation 0, tick 500 when not moving
+    models[BEAR]->setStillAnimation(0, 500);
 }

--- a/client/src/sge/ShittyGraphicsEngine.cpp
+++ b/client/src/sge/ShittyGraphicsEngine.cpp
@@ -74,7 +74,7 @@ void sge::loadModels() {
     // Modify ModelIndex enum to add more models
     std::string filePaths[NUM_MODELS] =
             {
-            "bear_walk_1.fbx",
+            "map_1_test.obj",
             "char_temp.obj",
             "bear_walk_2.glb"
             };


### PR DESCRIPTION
The bears move around now, with animation vs no animation based on whether they are moving and the animation frame displayed based on time since starting that animation. To add a new model of an existing general type (e.g. players), put the new glb file in models, add the file name to the vector in sge::loadModels, add another value to the ModelIndex enum, and set the animation frame when still in sge::loadModels using setStillAnimation. To add more animations to an existing general type (e.g. players), add another value to the PlayerAnimations enum in ClientGame, update the glb files for each of the models to include their versions of the new animation, and add logic to ClientGame that sets their animation to be the new animation in the appropriate circumstances. To add a completely new general type (e.g. the egg has a different set of animations from the player), add a new EggAnimations enum to ClientGame, and add a new vector to ClientGame similar to playerIndices to keep track of which movement entities fall into this category. Then you can proceed with adding models/animations according to the earlier instructions.
(I know it's messy how everything is spread between the ClientGame, the Client, and the sge stuff. I tried to do good abstraction things first and it became so much worse. This is the best I could come up with that wasn't ridiculous to implement/use, but obviously I'm open to ideas for how to make it cleaner)