### PR TITLE
Season effects

### DIFF
--- a/client/include/ClientGame.h
+++ b/client/include/ClientGame.h
@@ -93,6 +93,7 @@ public:
     float yaws[NUM_MOVEMENT_ENTITIES];
     float pitches[NUM_MOVEMENT_ENTITIES];
     float cameraDistances[NUM_MOVEMENT_ENTITIES];
+    int gameSeason;
 
     std::deque<BulletToRender> bulletQueue;
     int shootingEmo = 0;

--- a/client/src/Client.cpp
+++ b/client/src/Client.cpp
@@ -192,6 +192,8 @@ void clientLoop()
         sge::postprocessor.drawToScreen();
 
         // Draw UI
+        // printf("current season = %d\n", clientGame->gameSeason);
+
         sge::lineUIShaderProgram.drawCrossHair(clientGame->shootingEmo); // let clientGame decide the emotive scale
         clientGame->updateShootingEmo();
 

--- a/client/src/ClientGame.cpp
+++ b/client/src/ClientGame.cpp
@@ -41,6 +41,7 @@ void ClientGame::handleServerActionEvent(ServerToClientPacket& updatePacket) {
     memcpy(&pitches, &updatePacket.pitches, sizeof(pitches));
     memcpy(&cameraDistances, &updatePacket.cameraDistances, sizeof(cameraDistances));
     // std::printf("received yaws: %f, %f, %f, %f\n", updatePacket.yaws[0], updatePacket.yaws[1], updatePacket.yaws[2], updatePacket.yaws[3]);
+    memcpy(&gameSeason, &updatePacket.currentSeason, sizeof(gameSeason));
 
     updateAnimations(updatePacket.movementEntityStates);
 

--- a/common/GameConstants.h
+++ b/common/GameConstants.h
@@ -17,6 +17,13 @@ enum BallProjType {
     NUM_PROJ_TYPES
 };
 
+enum Season {
+    SPRING_SEASON,
+    SUMMER_SEASON,
+    AUTUMN_SEASON,
+    WINTER_SEASON
+};
+
 enum MovementEntityStateIndex {
     MOVING_HORIZONTALLY = 0,
     ON_GROUND = 1,

--- a/common/NetworkData.h
+++ b/common/NetworkData.h
@@ -80,6 +80,7 @@ struct ServerToClientPacket {
     float pitches[NUM_MOVEMENT_ENTITIES];
     float cameraDistances[NUM_PLAYER_ENTITIES];
     std::bitset<NUM_STATES> movementEntityStates[NUM_MOVEMENT_ENTITIES];
+    int currentSeason;
 };
 
 struct BulletTrail {

--- a/server/include/bge/Component.h
+++ b/server/include/bge/Component.h
@@ -25,8 +25,10 @@ namespace bge {
     struct VelocityComponent : Component<VelocityComponent> {
         VelocityComponent(float vx, float vy, float vz) {
             velocity = glm::vec3(vx, vy, vz);
+            timeOnGround = 0;
         }
         glm::vec3 velocity;
+        int timeOnGround;
         bool onGround;
     };
 

--- a/server/include/bge/System.h
+++ b/server/include/bge/System.h
@@ -178,4 +178,3 @@ namespace bge {
 		int counter;
 	};
 }
-

--- a/server/include/bge/System.h
+++ b/server/include/bge/System.h
@@ -37,20 +37,6 @@ namespace bge {
 
 	};
 
-	class ProjectileAccelerationSystem : public System {
-	public:
-		void update();
-		ProjectileAccelerationSystem(
-			World* gameWorld,
-			std::shared_ptr<ComponentManager<PositionComponent>> positionCM,
-			std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM,
-			std::shared_ptr<ComponentManager<MovementRequestComponent>> movementRequestCM,
-			std::shared_ptr<ComponentManager<JumpInfoComponent>> jumpInfoCM);
-	protected:
-		std::shared_ptr<ComponentManager<PositionComponent>> positionCM;
-		std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM;
-	};
-
 	class BoxCollisionSystem : public System {
 	public:
 		void update();
@@ -128,16 +114,6 @@ namespace bge {
 			std::shared_ptr<ComponentManager<PlayerDataComponent>> playerDataCM;
 	};
 
-    class CollisionSystem : public System {
-    public:
-        void update();
-        CollisionSystem(World* gameWorld, std::shared_ptr<ComponentManager<PositionComponent>> positionCM, std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM, std::shared_ptr<ComponentManager<JumpInfoComponent>> jumpInfoCM);
-    protected:
-        std::shared_ptr<ComponentManager<PositionComponent>> positionCM;
-        std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM;
-        std::shared_ptr<ComponentManager<JumpInfoComponent>> jumpInfoCM;
-    };
-
 	class SeasonAbilitySystem : public System {
 	public:
 		void update();
@@ -181,6 +157,25 @@ namespace bge {
 		std::shared_ptr<ComponentManager<MeshCollisionComponent>> meshCollisionCM;
 		std::shared_ptr<ComponentManager<HealthComponent>> healthCM;
 	};
-    
+
+	class SeasonEffectSystem : public System {
+	public:
+		void update();
+		SeasonEffectSystem(
+			World* gameWorld,
+			std::shared_ptr<ComponentManager<HealthComponent>> healthCM,
+			std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM,
+        	std::shared_ptr<ComponentManager<MovementRequestComponent>> movementRequestCM, 
+        	std::shared_ptr<ComponentManager<JumpInfoComponent>> jumpInfoCM,
+			std::shared_ptr<ComponentManager<SeasonAbilityStatusComponent>> seasonAbilityStatusCM
+		);
+	protected:
+		std::shared_ptr<ComponentManager<HealthComponent>> healthCM;
+		std::shared_ptr<ComponentManager<VelocityComponent>> velocityCM;
+        std::shared_ptr<ComponentManager<MovementRequestComponent>> movementRequestCM;
+        std::shared_ptr<ComponentManager<JumpInfoComponent>> jumpInfoCM;
+		std::shared_ptr<ComponentManager<SeasonAbilityStatusComponent>> seasonAbilityStatusCM;
+		int counter;
+	};
 }
 

--- a/server/include/bge/World.h
+++ b/server/include/bge/World.h
@@ -95,6 +95,8 @@ namespace bge {
 
             Entity players[NUM_PLAYER_ENTITIES];
 
+            int currentSeason;
+
         private:
             void initMesh();
             std::vector<unsigned int> determineBucket(float x, float z);

--- a/server/src/bge/EventHandler.cpp
+++ b/server/src/bge/EventHandler.cpp
@@ -60,7 +60,7 @@ namespace bge {
 		HealthComponent& targetHealth = healthCM->lookup(target);
 		targetHealth.healthPoint -= 10;
 
-		std::printf("player %d has %d hp left\n", target.id, targetHealth.healthPoint);
+		// std::printf("player %d has %d hp left\n", target.id, targetHealth.healthPoint);
 		
 		// switch positions if target is 'dead'
 		if (targetHealth.healthPoint <= 0) {

--- a/server/src/bge/System.cpp
+++ b/server/src/bge/System.cpp
@@ -616,17 +616,19 @@ namespace bge {
 
     void SeasonEffectSystem::update() {
 
-        if (counter > 400) {
+        // Change this to make each season longer or shorter
+        if (counter > 500) {
             counter = 0;
             world->currentSeason = (world->currentSeason+1)%4;
-            std::printf("Current Season is %d\n", world->currentSeason);
+            // std::printf("Current Season is %d\n", world->currentSeason);
         }
 
         if (world->currentSeason == SPRING_SEASON) {
             for (Entity e : registeredEntities) {
                 HealthComponent& health = healthCM->lookup(e);
-
-                health.healthPoint = std::min(100,health.healthPoint+1);
+                if (counter % 50 == 0) {
+                    health.healthPoint = std::min(100,health.healthPoint+5);
+                }
             }
         } else if (world->currentSeason == SUMMER_SEASON) {
             for (Entity e : registeredEntities) {
@@ -636,28 +638,32 @@ namespace bge {
 
                 if (!jump.jumpHeld && req.jumpRequested && jump.doubleJumpUsed == MAX_JUMPS_ALLOWED) {
                     jump.doubleJumpUsed++;
-                    vel.velocity.y = JUMP_SPEED*2;
+                    vel.velocity.y = JUMP_SPEED*1.25;
                     jump.jumpHeld = true;
                 }
             }
         } else if (world->currentSeason == AUTUMN_SEASON) {
             for (Entity e : registeredEntities) {
                 SeasonAbilityStatusComponent& seasonAbilityStatus = seasonAbilityStatusCM->lookup(e);
-
-                if (seasonAbilityStatus.coolDown < SEASON_ABILITY_CD/2) {
+                // Reduce cooldown by 66%
+                if (seasonAbilityStatus.coolDown < SEASON_ABILITY_CD*2/3) {
                     seasonAbilityStatus.coolDown = 0;
                 }
             }
         } else if (world->currentSeason == WINTER_SEASON) {
             for (Entity e : registeredEntities) {
+                MovementRequestComponent& req = movementRequestCM->lookup(e);
                 VelocityComponent& vel = velocityCM->lookup(e);
-                if (vel.onGround) {
+                if (!req.jumpRequested) {
                     vel.timeOnGround++;
-                    float speedMult = std::min(vel.timeOnGround, 10) * 0.33;
+                    float speedMult = 1 + std::min(vel.timeOnGround, 120) * 0.002;
                     vel.velocity.x *= speedMult;
                     vel.velocity.z *= speedMult;
                 } else {
                     vel.timeOnGround = 0;
+                    float speedMult = 0.5;
+                    vel.velocity.x *= speedMult;
+                    vel.velocity.z *= speedMult;
                 }
             }
         }

--- a/server/src/bge/System.cpp
+++ b/server/src/bge/System.cpp
@@ -623,11 +623,14 @@ namespace bge {
             // std::printf("Current Season is %d\n", world->currentSeason);
         }
 
+        // For Debugging
+        // world->currentSeason = WINTER_SEASON;
+
         if (world->currentSeason == SPRING_SEASON) {
             for (Entity e : registeredEntities) {
                 HealthComponent& health = healthCM->lookup(e);
                 if (counter % 50 == 0) {
-                    health.healthPoint = std::min(100,health.healthPoint+5);
+                    health.healthPoint = std::min(PLAYER_MAX_HEALTH,health.healthPoint+5);
                 }
             }
         } else if (world->currentSeason == SUMMER_SEASON) {
@@ -654,14 +657,14 @@ namespace bge {
             for (Entity e : registeredEntities) {
                 MovementRequestComponent& req = movementRequestCM->lookup(e);
                 VelocityComponent& vel = velocityCM->lookup(e);
-                if (!req.jumpRequested) {
+                if (vel.onGround) {
                     vel.timeOnGround++;
-                    float speedMult = 1 + std::min(vel.timeOnGround, 120) * 0.002;
+                    float speedMult = 1 + std::min(vel.timeOnGround, 90) * 0.004;
                     vel.velocity.x *= speedMult;
                     vel.velocity.z *= speedMult;
                 } else {
                     vel.timeOnGround = 0;
-                    float speedMult = 0.5;
+                    float speedMult = 0.8;
                     vel.velocity.x *= speedMult;
                     vel.velocity.z *= speedMult;
                 }

--- a/server/src/bge/World.cpp
+++ b/server/src/bge/World.cpp
@@ -38,6 +38,7 @@ namespace bge {
         std::shared_ptr<BulletSystem> bulletSystem = std::make_shared<BulletSystem>(this, positionCM, movementRequestCM, cameraCM, playerDataCM, healthCM);
         std::shared_ptr<SeasonAbilitySystem> seasonAbilitySystem = std::make_shared<SeasonAbilitySystem>(this, movementRequestCM, playerDataCM, seasonAbilityStatusCM, ballProjDataCM, positionCM, velocityCM, cameraCM);
         std::shared_ptr<ProjectileStateSystem> projectileStateSystem = std::make_shared<ProjectileStateSystem>(this, playerDataCM, statusEffectsCM, ballProjDataCM, positionCM, velocityCM, meshCollisionCM, healthCM);
+        std::shared_ptr<SeasonEffectSystem> seasonEffectSystem = std::make_shared<SeasonEffectSystem>(this, healthCM, velocityCM, movementRequestCM, jumpInfoCM, seasonAbilityStatusCM);
 
         // init players
         std::vector<glm::vec3> playerInitPositions = {  glm::vec3(11,5,17),         // hilltop
@@ -87,6 +88,7 @@ namespace bge {
             cameraSystem->registerEntity(newPlayer);
             bulletSystem->registerEntity(newPlayer);
             seasonAbilitySystem->registerEntity(newPlayer);
+            seasonEffectSystem->registerEntity(newPlayer);
         }
 
         // init egg
@@ -150,20 +152,26 @@ namespace bge {
             }
         }
 
+        currentSeason = SPRING_SEASON;
+
         // Process player input
         systems.push_back(playerAccSystem);
         // Process position of the player camera
         systems.push_back(cameraSystem);
+        // Process seasonal effects
+        systems.push_back(seasonEffectSystem);
         // Process bullet shooting
         systems.push_back(bulletSystem);
+        // Process seasonal skill shooting
+        systems.push_back(seasonAbilitySystem);
+        // Process seasonal skill hits
+        systems.push_back(projectileStateSystem);
         // Process collision with boxes
         systems.push_back(boxCollisionSystem);
         // Process collision with world mesh
         systems.push_back(movementSystem);
         // Process movement of the egg
         systems.push_back(eggMovementSystem);
-        systems.push_back(seasonAbilitySystem);
-        systems.push_back(projectileStateSystem);
     }
 
 

--- a/server/src/bge/World.cpp
+++ b/server/src/bge/World.cpp
@@ -551,6 +551,7 @@ namespace bge {
             packet.movementEntityStates[i][ON_GROUND] = velocities[i].onGround;
             packet.movementEntityStates[i][MOVING_HORIZONTALLY] = velocities[i].velocity.x != 0 || velocities[i].velocity.z != 0;
         }
+        packet.currentSeason = currentSeason;
     }
 
     void World::fillInBulletData(BulletPacket& packet) {


### PR DESCRIPTION
Every season now has an effect on all players.
Spring: regain 5 health every 50 game ticks
Summer: triple jump, with the 3rd jump being more powerful
Autumn: reduce season ability (fireball) cooldown to 33%
Winter: jumping makes you slower, the longer you stay on the ground, the faster you go (to a cap)
Seasons change automatically (currently every 500 game ticks)